### PR TITLE
Update rule 3.4.3 to add content to hosts.deny

### DIFF
--- a/manifests/redhat7/rule/v_2_1_1/rule_3_4_2.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_3_4_2.pp
@@ -18,7 +18,7 @@ file{ '(3.4.2) Ensure /etc/hosts.allow is configured (Scored)':
 file{ '(3.4.3) Ensure /etc/hosts.deny is configured (Scored)':
   ensure => file,
   path   => '/etc/hosts.deny',
-    #no content class should be used to ensure file not configure it.
+  content => 'ALL: ALL',
   }
 
 


### PR DESCRIPTION
CIS Control requests to have /etc/hosts.deny populated with ALL:ALL (Not to just check that the file exists)