### PR TITLE
Update rule_5_2 to avoid duplicated entries and Update regex on rule_5_6 to avoid the same

### DIFF
--- a/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
@@ -35,7 +35,6 @@ class cis_benchmarks::redhat7::rule::v_2_1_1::rule_5_2 (
         path     => $file,
         line     => $setting,
         match    => "^${matching_setting}",
-        multiple => 'true',
         notify   => Service['(5.2) - Ensure SSH Server Configuration'],
       }
     }

--- a/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
@@ -28,11 +28,15 @@ class cis_benchmarks::redhat7::rule::v_2_1_1::rule_5_2 (
     }
 
   $cis_ssh_settings.each |$rule, $setting| {
-    file_line { $rule:
-      ensure => present,
-      path   => $file,
-      line   => $setting,
-      notify => Service['(5.2) - Ensure SSH Server Configuration'],
+    $matching_setting    =  split($setting, '[\s*]')[0]
+    if $matching_setting =~ /^(?![#])/ {
+      file_line { $rule:
+        ensure => present,
+        path   => $file,
+        line   => $matching_setting,
+        match  => split($setting, '[\s*]')[0],
+        notify => Service['(5.2) - Ensure SSH Server Configuration'],
+      }
     }
   }
 

--- a/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
@@ -35,6 +35,7 @@ class cis_benchmarks::redhat7::rule::v_2_1_1::rule_5_2 (
         path     => $file,
         line     => $setting,
         match    => "^${matching_setting}",
+        multiple => 'true',
         notify   => Service['(5.2) - Ensure SSH Server Configuration'],
       }
     }

--- a/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
@@ -31,10 +31,11 @@ class cis_benchmarks::redhat7::rule::v_2_1_1::rule_5_2 (
     $matching_setting    =  split($setting, '[\s*]')[0]
     if $matching_setting =~ /^(?![#])/ {
       file_line { $rule:
-        ensure => present,
-        path   => $file,
-        line   => $matching_setting,
-        match  => split($setting, '[\s*]')[0],
+        ensure   => present,
+        path     => $file,
+        line     => $matching_setting,
+        match    => split($setting, '[\s*]')[0],
+        multiple => 'true',
         notify => Service['(5.2) - Ensure SSH Server Configuration'],
       }
     }

--- a/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
@@ -34,7 +34,7 @@ class cis_benchmarks::redhat7::rule::v_2_1_1::rule_5_2 (
         ensure   => present,
         path     => $file,
         line     => $setting,
-        match    => $matching_setting,
+        match    => "^${matching_setting}",
         notify   => Service['(5.2) - Ensure SSH Server Configuration'],
       }
     }

--- a/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
@@ -35,7 +35,6 @@ class cis_benchmarks::redhat7::rule::v_2_1_1::rule_5_2 (
         path     => $file,
         line     => $setting,
         match    => $matching_setting,
-        multiple => 'true',
         notify   => Service['(5.2) - Ensure SSH Server Configuration'],
       }
     }

--- a/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_5_2.pp
@@ -33,10 +33,10 @@ class cis_benchmarks::redhat7::rule::v_2_1_1::rule_5_2 (
       file_line { $rule:
         ensure   => present,
         path     => $file,
-        line     => $matching_setting,
-        match    => split($setting, '[\s*]')[0],
+        line     => $setting,
+        match    => $matching_setting,
         multiple => 'true',
-        notify => Service['(5.2) - Ensure SSH Server Configuration'],
+        notify   => Service['(5.2) - Ensure SSH Server Configuration'],
       }
     }
   }

--- a/manifests/redhat7/rule/v_2_1_1/rule_5_6.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_5_6.pp
@@ -5,7 +5,7 @@ class cis_benchmarks::redhat7::rule::v_2_1_1::rule_5_6{
       ensure  => present,
       path    => '/etc/pam.d/su',
       line    => 'auth 	required pam_wheel.so use_uid',
-      match   => '^#auth.*required.*pam_wheel.so',
+      match   => '^auth.*required.*pam_wheel.so',
       replace => true,
     }
 } #EOF


### PR DESCRIPTION
1. Update rule_5_2 to avoid duplicated entries

As example, we got te following duplicate (with the proposed match settings, this will generate an error, forcing the admin to delete one of these lines)
$ sudo grep "^X11Forwarding" /etc/ssh/sshd_config
X11Forwarding yes
X11Forwarding no


2. Update regex on rule_5_6 to avoid duplicated entries

The following happened previously...
$ sudo grep '^auth.*required.*pam_wheel.so' /etc/pam.d/su | wc -l
36
