### PR TITLE
Fix process name from snpd to snmpd

### DIFF
--- a/manifests/redhat7/rule/v_2_1_1/rule_2_2_14.pp
+++ b/manifests/redhat7/rule/v_2_1_1/rule_2_2_14.pp
@@ -1,7 +1,7 @@
 # 2.2.14 Ensure SNMP Server is not enabled (Scored)
 class cis_benchmarks::redhat7::rule::v_2_1_1::rule_2_2_14 {
   service{ '(2.2.14) - Disable snmpd (Scored)':
-    name   => 'snpd',
+    name   => 'snmpd',
     enable => false,
   }
 } #EOF


### PR DESCRIPTION
Rule 2.2.14 wasn't successful because the process name was hardcoded wrong.